### PR TITLE
(mobile) 운영진 명단 소개 텍스트의 행간 조정

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -64,6 +64,7 @@ const OrganizerWrap = styled(({ className, children }) => {
     &::after {
       padding: 0 6px;
       content: "|";
+      line-height: 1.75;
     }
   }
 `;


### PR DESCRIPTION
모바일 화면에서 Footer 컴포넌트가 깨져보이는 것 같아서 행간을 조정했습니다.

|  **as-is** | **to-be**  | 
|---|---|
|  <img width="326" alt="스크린샷 2023-10-03 17 54 04" src="https://github.com/icpc-sinchon/icpc-sinchon.github.io/assets/2427963/6e380051-7ad9-4809-a8b9-0ed33d6e5a40"> |  <img width="324" alt="스크린샷 2023-10-03 17 54 12" src="https://github.com/icpc-sinchon/icpc-sinchon.github.io/assets/2427963/cbf6ea42-a9d0-40dd-8f12-2ac418fcb96c">  |